### PR TITLE
Feature/#17 - 작품 등록 API 구현 및 공통 컴포넌트 확장성 추가 

### DIFF
--- a/src/apis/artworkRegister/postArtworkRegister.ts
+++ b/src/apis/artworkRegister/postArtworkRegister.ts
@@ -1,0 +1,45 @@
+import { instance } from '@/apis/axios';
+import { TGetResponse } from '@/apis/type';
+import { TArtworkRegisterFormData } from './type';
+
+/**
+ * 작품 등록 API 함수
+ * @param data 작품 등록 폼 데이터 (파일 전송을 위해 FormData 형태로 변환됩니다.)
+ * @returns 등록 결과를 포함한 응답(TGetResponse<void>)
+ */
+export const postArtworkRegister = async (
+  data: TArtworkRegisterFormData
+): Promise<TGetResponse<void>> => {
+  // 이미지 파일과 텍스트 필드를 함께 전송하기 위해 FormData 사용
+  const formData = new FormData();
+
+  // images 필드는 File 배열이므로 반복문을 사용하여 첨부
+  data.images.forEach((file) => {
+    formData.append('images', file);
+  });
+
+  // 나머지 텍스트 데이터 추가
+  formData.append('theme', data.theme);
+  formData.append('form', data.form);
+  formData.append('title', data.title);
+  formData.append('year', data.year);
+  formData.append('genre', data.genre);
+  formData.append('material', data.material);
+  formData.append('description', data.description);
+  formData.append('height', data.height);
+  formData.append('width', data.width);
+  formData.append('number', data.number);
+  formData.append('frame', data.frame);
+
+  const response = await instance.post<TGetResponse<void>>(
+    '/api/artworks',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  console.log(response.data);
+  return response.data;
+};

--- a/src/apis/artworkRegister/type.ts
+++ b/src/apis/artworkRegister/type.ts
@@ -1,0 +1,14 @@
+export type TArtworkRegisterFormData = {
+  images: File[];
+  theme: string;
+  form: string;
+  title: string;
+  year: string;
+  genre: string;
+  material: string;
+  description: string;
+  height: string;
+  width: string;
+  number: string;
+  frame: string;
+};

--- a/src/apis/auctionRegister/postAuctionRegister.ts
+++ b/src/apis/auctionRegister/postAuctionRegister.ts
@@ -1,0 +1,16 @@
+import { instance } from '@/apis/axios';
+import { TGetResponse } from '@/apis/type';
+import { TAuctionRegisterFormData } from './type';
+
+/**
+ * 경매 등록 API 함수
+ * @param data 경매 등록 폼 데이터
+ * @returns 등록 결과를 포함한 응답(TGetResponse<void>)
+ * @author 홍규진
+ */
+export const postAuctionRegister = async (
+  data: TAuctionRegisterFormData
+): Promise<TGetResponse<void>> => {
+  const response = await instance.post('/api/auction/register', data);
+  return response.data;
+};

--- a/src/apis/auctionRegister/type.ts
+++ b/src/apis/auctionRegister/type.ts
@@ -7,3 +7,12 @@ export type TGetAvailableArtworksResponse = {
   title: string;
   thumbnail_image_url: string;
 };
+
+/**
+ * 경매 등록 폼 데이터
+ * @author 홍규진
+ */
+export type TAuctionRegisterFormData = {
+  artwork_id: number | null;
+  start_price: number | null;
+};

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -25,13 +25,14 @@ type TAnotherToken = {
 type TAuthResponse = {
   accessToken: string;
 };
-// const DUMMY_ACCESS_TOKEN =
-//   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InJ5dXNlb25naG83QGRndS5hYy5rciIsImlhdCI6MTczOTIwNDY5NiwiZXhwIjoxNzQxNzk2Njk2fQ.iWwnAhIzse5UwvHpR5uWa2o0HRM5G14ikeAtYf_BDec';
+
+const DUMMY_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InJ5dXNlb25naG83QGRndS5hYy5rciIsImlhdCI6MTczOTIwNDY5NiwiZXhwIjoxNzQxNzk2Njk2fQ.iWwnAhIzse5UwvHpR5uWa2o0HRM5G14ikeAtYf_BDec';
 export const instance: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_APP_SERVER_URL,
   headers: {
-    Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-    // Authorization: `Bearer ${DUMMY_ACCESS_TOKEN}`,
+    // Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+    Authorization: `Bearer ${DUMMY_ACCESS_TOKEN}`,
   },
   withCredentials: true,
 });

--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -25,11 +25,13 @@ type TAnotherToken = {
 type TAuthResponse = {
   accessToken: string;
 };
-
+// const DUMMY_ACCESS_TOKEN =
+//   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InJ5dXNlb25naG83QGRndS5hYy5rciIsImlhdCI6MTczOTIwNDY5NiwiZXhwIjoxNzQxNzk2Njk2fQ.iWwnAhIzse5UwvHpR5uWa2o0HRM5G14ikeAtYf_BDec';
 export const instance: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_APP_SERVER_URL,
   headers: {
     Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+    // Authorization: `Bearer ${DUMMY_ACCESS_TOKEN}`,
   },
   withCredentials: true,
 });

--- a/src/components/common/ArtWork/index.style.ts
+++ b/src/components/common/ArtWork/index.style.ts
@@ -74,7 +74,7 @@ export const Artist = styled.p`
 `;
 
 export const Title = styled.p`
-  ${(theme) => theme.theme.typography['16']}
+  ${(theme) => theme.theme.typography['14']}
   margin: 0;
 `;
 

--- a/src/components/common/ArtWork/index.tsx
+++ b/src/components/common/ArtWork/index.tsx
@@ -18,7 +18,7 @@ import EmptyHeart from '@assets/svg/empty-heart.svg?react';
 import theme from '@styles/theme.ts';
 interface ArtworkProps {
   imageUrl: string;
-  artist: string;
+  artist?: string;
   title: string;
   artworkWidth?: number;
   artworkHeight?: number;
@@ -88,7 +88,7 @@ export const Artwork = ({
         )}
       </ImageContainer>
       <ArtworkInfo>
-        <Artist>{artist}</Artist>
+        {artist && <Artist>{artist}</Artist>}
         <Title>{title}</Title>
         {formattedSize && <Size>{formattedSize}</Size>}
         {formattedPrice && <Price>{formattedPrice}</Price>}

--- a/src/components/common/ThemeChooser/index.tsx
+++ b/src/components/common/ThemeChooser/index.tsx
@@ -3,22 +3,32 @@ import { ThemeButton, Wrapper } from './index.style';
 
 interface ThemeChooserProps {
   themes?: string[];
+  selectedTheme?: string;
+  onThemeChange?: (theme: string) => void;
 }
 
 /**
  * 테마 선택 컴포넌트입니다.
- * 부모 컴포넌트에서 테마 목록을 전달받아 테마 버튼을 렌더링합니다.
- * 테마 버튼을 클릭하면 해당 테마가 선택됩니다.
+ * 부모 컴포넌트에서 테마 목록과 선택된 테마 값을 전달받아 테마 버튼을 렌더링합니다.
+ * 테마 버튼을 클릭하면 해당 테마가 선택되고, 만약 onThemeChange가 제공되면 부모에게 값 변경을 알려줍니다.
  * @param themes 테마 목록 (기본값: ['풍경', '인물', '정물', '동물', '추상', '팝아트', '오브제'])
- * @author ???, 홍규진
  */
 const ThemeChooser = ({
   themes = ['풍경', '인물', '정물', '동물', '추상', '팝아트', '오브제'],
+  selectedTheme,
+  onThemeChange,
 }: ThemeChooserProps) => {
-  const [selectedTheme, setSelectedTheme] = useState<string>(themes[0]);
+  // 부모가 제어하지 않을 경우 내부 상태로 관리
+  const [internalTheme, setInternalTheme] = useState<string>(themes[0]);
+  const currentTheme =
+    selectedTheme !== undefined ? selectedTheme : internalTheme;
 
   const handleThemeClick = (theme: string) => {
-    setSelectedTheme(theme);
+    if (onThemeChange) {
+      onThemeChange(theme);
+    } else {
+      setInternalTheme(theme);
+    }
   };
 
   return (
@@ -26,7 +36,7 @@ const ThemeChooser = ({
       {themes.map((theme) => (
         <ThemeButton
           key={theme}
-          $isActive={selectedTheme === theme}
+          $isActive={currentTheme === theme}
           onClick={() => handleThemeClick(theme)}
         >
           {theme}

--- a/src/constants/mutationKey.ts
+++ b/src/constants/mutationKey.ts
@@ -1,0 +1,37 @@
+import { postAuthRegister } from '@/apis/register/postAuthRegister';
+import { postAuctionRegister } from '@/apis/auctionRegister/postAuctionRegister';
+import { postArtworkRegister } from '@/apis/artworkRegister/postArtworkRegister';
+import { getAvailableArtworksQuery } from '@/constants/queryKeys';
+/**
+ * 인증 회원가입 뮤테이션
+ * @author 홍규진
+ * */
+export const postAuthRegisterMutation = () => {
+  return {
+    mutationKey: ['auth'],
+    mutationFn: postAuthRegister,
+  };
+};
+
+/**
+ * 경매 등록 뮤테이션
+ * @author 홍규진
+ * */
+export const postAuctionRegisterMutation = () => {
+  return {
+    mutationKey: [...getAvailableArtworksQuery().queryKey],
+    mutationFn: postAuctionRegister,
+  };
+};
+
+/**
+ * 작품 등록 뮤테이션
+ * TODO-[홍규진] 작품 등록 후, 홈 화면 내 작품 쿼리 키 지정시 해당 키로 수정 필요
+ * @author 홍규진
+ * */
+export const postArtworkRegisterMutation = () => {
+  return {
+    mutationKey: ['artwork'],
+    mutationFn: postArtworkRegister,
+  };
+};

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,14 +1,13 @@
-import { postArtworkRegister } from '@/apis/artworkRegister/postArtworkRegister';
 import { getAvailableArtworks } from '@/apis/auctionRegister/getAvailableArtworks';
 import { getArtistList } from '@/apis/Example/artist';
 import { TGetArtistListRequestParams } from '@/apis/Example/type';
-import { postAuthRegister } from '@/apis/register/postAuthRegister';
 
 /**
  * 아티스트들의 정보를 받아오고, 관리하기 위한 쿼리 키로 함수와 묶어서 사용합니다.
  * 단, pagenation 이 필요한 경우엔 다음과 같이 page 와 keyword 를 이용해 작성합니다. 이 때, queryKey 지정 여부에 따라서 데이터를 다시 못 받아오는 경우도 있으니, 검색이 필요한 경우엔 keyword 와 연관되게 키를 지정 후 데이터를 가져옵니다.
  * @author 홍규진
  * */
+
 export const getArtistListQuery = () => {
   return {
     queryKey: ['artistList'],
@@ -25,27 +24,5 @@ export const getAvailableArtworksQuery = () => {
   return {
     queryKey: ['availableArtworks'],
     queryFn: getAvailableArtworks,
-  };
-};
-
-/**
- * 인증 회원가입 쿼리
- * @author 홍규진
- * */
-export const postAuthRegisterQuery = () => {
-  return {
-    queryKey: ['postAuthRegister'],
-    queryFn: postAuthRegister,
-  };
-};
-
-/**
- * 작품 등록 쿼리
- * @author 홍규진
- * */
-export const postArtworkRegisterQuery = () => {
-  return {
-    queryKey: ['postArtworkRegister'],
-    queryFn: postArtworkRegister,
   };
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,3 +1,4 @@
+import { postArtworkRegister } from '@/apis/artworkRegister/postArtworkRegister';
 import { getAvailableArtworks } from '@/apis/auctionRegister/getAvailableArtworks';
 import { getArtistList } from '@/apis/Example/artist';
 import { TGetArtistListRequestParams } from '@/apis/Example/type';
@@ -35,5 +36,16 @@ export const postAuthRegisterQuery = () => {
   return {
     queryKey: ['postAuthRegister'],
     queryFn: postAuthRegister,
+  };
+};
+
+/**
+ * 작품 등록 쿼리
+ * @author 홍규진
+ * */
+export const postArtworkRegisterQuery = () => {
+  return {
+    queryKey: ['postArtworkRegister'],
+    queryFn: postArtworkRegister,
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App.tsx';
 import { QueryClientProvider } from './contexts/query/QueryClientProvider.tsx';
 import { AuthProvider } from './contexts/authContext.tsx';
 import * as Kakao from 'kakao-js-sdk';
-
+import { Toaster } from 'sonner';
 Kakao.initKakao(import.meta.env.VITE_KAKAO_API_KEY);
 
 createRoot(document.getElementById('root')!).render(
@@ -12,6 +12,7 @@ createRoot(document.getElementById('root')!).render(
     <QueryClientProvider>
       <AuthProvider>
         <App />
+        <Toaster />
       </AuthProvider>
     </QueryClientProvider>
   </StrictMode>

--- a/src/pages/artwork-register/components/GenreCheckBox/index.tsx
+++ b/src/pages/artwork-register/components/GenreCheckBox/index.tsx
@@ -29,7 +29,7 @@ const GenreCheckBox = ({ onChange }: GenreCheckBoxProps) => {
           />
         </GenreItem>
       ))}
-      {selectedGenre === 'other' && (
+      {selectedGenre === '기타' && (
         <Input
           placeholder="기타 장르를 입력하세요"
           value={otherGenre}

--- a/src/pages/artwork-register/components/MaterialCheckBox/index.tsx
+++ b/src/pages/artwork-register/components/MaterialCheckBox/index.tsx
@@ -29,7 +29,7 @@ const MaterialCheckBox = ({ onChange }: MaterialCheckBoxProps) => {
           />
         </MaterialItem>
       ))}
-      {selectedMaterial === 'other' && (
+      {selectedMaterial === '기타' && (
         <Input
           placeholder="기타 재료를 입력하세요"
           value={otherMaterial}

--- a/src/pages/artwork-register/constants/genres.ts
+++ b/src/pages/artwork-register/constants/genres.ts
@@ -1,17 +1,16 @@
 export const genres = [
-  { id: 'painting', label: '회화' },
-  { id: 'print', label: '판화' },
-  { id: 'sculpture', label: '조형' },
-  { id: 'photography', label: '사진' },
-  { id: 'digital', label: '디지털' },
-  { id: 'art', label: '아트' },
-  { id: 'other', label: '기타' },
+  { id: '회화', label: '회화' },
+  { id: '판화', label: '판화' },
+  { id: '조형', label: '조형' },
+  { id: '사진', label: '사진' },
+  { id: '디지털', label: '디지털' },
+  { id: '기타', label: '기타' },
 ];
 
 export const materials = [
-  { id: 'canvas', label: '캔버스' },
-  { id: 'oil', label: '유채' },
-  { id: 'acrylic', label: '아크릴' },
-  { id: 'watercolor', label: '수채' },
-  { id: 'other', label: '기타' },
+  { id: '캔버스', label: '캔버스' },
+  { id: '유채', label: '유채' },
+  { id: '아크릴', label: '아크릴' },
+  { id: '수채', label: '수채' },
+  { id: '기타', label: '기타' },
 ];

--- a/src/pages/artwork-register/hooks/useArtworkRegisterForm.ts
+++ b/src/pages/artwork-register/hooks/useArtworkRegisterForm.ts
@@ -1,7 +1,10 @@
+import { postArtworkRegisterQuery } from '@/constants/queryKeys';
 import { useState } from 'react';
 
 type TArtworkRegisterFormData = {
   images: File[];
+  theme: string;
+  form: string;
   title: string;
   year: string;
   genre: string;
@@ -10,11 +13,13 @@ type TArtworkRegisterFormData = {
   height: string;
   width: string;
   number: string;
-  frameNumber: string;
+  frame: string;
 };
 const useArtworkForm = () => {
   const [formData, setFormData] = useState<TArtworkRegisterFormData>({
     images: [],
+    theme: '',
+    form: '',
     title: '',
     year: '',
     genre: '',
@@ -23,7 +28,7 @@ const useArtworkForm = () => {
     height: '',
     width: '',
     number: '',
-    frameNumber: '',
+    frame: '',
   });
 
   /**
@@ -43,7 +48,7 @@ const useArtworkForm = () => {
       height,
       width,
       number,
-      frameNumber,
+      frame,
     } = formData;
 
     if (
@@ -56,7 +61,7 @@ const useArtworkForm = () => {
       !height ||
       !width ||
       !number ||
-      !frameNumber
+      !frame
     ) {
       console.log('유효성 검사 실패');
 
@@ -76,8 +81,8 @@ const useArtworkForm = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (validateForm(formData)) {
-      console.log(formData);
-      console.log('유효성 검사 성공');
+      console.log('유효성 검사 성공 API 요청');
+      postArtworkRegisterQuery().queryFn(formData);
     } else {
       console.log('유효성 검사 실패');
       alert('모든 항목을 입력해주세요.');

--- a/src/pages/artwork-register/index.tsx
+++ b/src/pages/artwork-register/index.tsx
@@ -30,10 +30,21 @@ export const ArtworkRegister = () => {
           카테고리
         </Text>
         <ArtworkDetailBelowLabel label="테마 선택">
-          <ThemeChooser />
+          <ThemeChooser
+            selectedTheme={formData.theme}
+            onThemeChange={(theme) => {
+              setFormData((prev) => ({ ...prev, theme }));
+            }}
+          />
         </ArtworkDetailBelowLabel>
         <ArtworkDetailBelowLabel label="테마">
-          <ThemeChooser themes={sizeThemes} />
+          <ThemeChooser
+            themes={sizeThemes}
+            selectedTheme={formData.form}
+            onThemeChange={(form) => {
+              setFormData((prev) => ({ ...prev, form }));
+            }}
+          />
         </ArtworkDetailBelowLabel>
         <Divider />
 
@@ -150,11 +161,11 @@ export const ArtworkRegister = () => {
               type="number"
               style={{ width: '40%' }}
               placeholder="액자 입력하세요"
-              value={formData.frameNumber}
+              value={formData.frame}
               onChange={(e) => {
                 setFormData((prev) => ({
                   ...prev,
-                  frameNumber: e.target.value,
+                  frame: e.target.value,
                 }));
               }}
             />

--- a/src/pages/artwork-register/index.tsx
+++ b/src/pages/artwork-register/index.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   Input,
   TextArea,
-  Button,
   ImageRegisterSection,
   ArtworkSizeDetailContainer,
   ButtonContainer,
@@ -18,6 +17,7 @@ import useArtworkForm from './hooks/useArtworkRegisterForm.ts';
 import Divider from '@/components/common/Divider';
 import { sizeThemes } from '@/pages/artwork-register/constants/themes';
 import ImageUploader from './components/ImageUploader/index.tsx';
+import { CommonButton } from '@/components/common/CommonButton/index.tsx';
 
 export const ArtworkRegister = () => {
   const { formData, setFormData, handleSubmit } = useArtworkForm();
@@ -184,18 +184,20 @@ export const ArtworkRegister = () => {
             />
           </ArtworkDetailBelowLabel>
           <ButtonContainer>
-            <Button
-              style={{
-                backgroundColor: 'white',
-                color: 'black',
-                border: '1px solid black',
-                borderRadius: '4px',
-              }}
-              type="submit"
-            >
-              취소하기
-            </Button>
-            <Button>등록하기</Button>
+            <CommonButton
+              text="취소하기"
+              color="black"
+              background="white"
+              borderColor="black"
+              borderRadius="0px"
+            />
+            <CommonButton
+              text="등록하기"
+              color="white"
+              background="black"
+              borderColor="black"
+              borderRadius="0px"
+            />
           </ButtonContainer>
         </Form>
       </Container>

--- a/src/pages/auction-register/components/AuctionModal/index.style.ts
+++ b/src/pages/auction-register/components/AuctionModal/index.style.ts
@@ -1,0 +1,75 @@
+import theme from '@/styles/theme';
+import styled from '@emotion/styled';
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ModalContainer = styled.div`
+  background: ${theme.colors.white};
+  border-radius: 8px;
+  width: 500px;
+  max-width: 90%;
+  padding: 20px;
+`;
+
+export const ModalHeader = styled.div`
+  margin-bottom: 15px;
+  text-align: center;
+`;
+
+export const ModalContent = styled.div`
+  margin-bottom: 15px;
+`;
+
+export const ModalImageContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 40px;
+`;
+
+export const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: auto;
+`;
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+`;
+export const Input = styled.input`
+  width: 80%;
+  padding: 8px;
+  box-sizing: border-box;
+  border: 1px solid ${theme.colors.lightGray};
+  text-align: right;
+`;
+export const Title = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  display: flex;
+  justify-content: flex-start;
+  ${(theme) => theme.theme.typography['14']}
+`;

--- a/src/pages/auction-register/components/AuctionModal/index.tsx
+++ b/src/pages/auction-register/components/AuctionModal/index.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import {
+  ModalOverlay,
+  ModalContainer,
+  ModalHeader,
+  ModalContent,
+  ModalFooter,
+  Image,
+  Input,
+  InputContainer,
+  Title,
+  ModalImageContainer,
+} from './index.style.ts';
+import { CommonButton } from '@/components/common/CommonButton';
+import { Text } from '@/styles/text.tsx';
+
+import theme from '@/styles/theme.ts';
+
+interface AuctionModalProps {
+  isOpen: boolean;
+  imageSrc: string | undefined;
+  title: string | undefined;
+  onClose: () => void;
+  onConfirm: (startPrice: number) => void;
+}
+
+const AuctionModal = ({
+  isOpen,
+  imageSrc,
+  title,
+  onClose,
+  onConfirm,
+}: AuctionModalProps) => {
+  const [startPrice, setStartPrice] = useState<number | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    if (startPrice === null) {
+      alert('시작 금액을 입력해주세요.');
+      return;
+    }
+    onConfirm(startPrice);
+  };
+  const formatPrice = (price: number | null) => {
+    return price !== null
+      ? price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      : '';
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/,/g, ''); // 쉼표 제거
+    // 숫자만 허용하고, 빈 문자열일 경우 null로 설정
+    const numericValue = value.match(/^\d*$/) ? Number(value) : null;
+    setStartPrice(numericValue);
+  };
+  return (
+    <ModalOverlay onClick={onClose}>
+      <ModalContainer onClick={(e) => e.stopPropagation()}>
+        <ModalHeader>
+          <Text size={20} weight="regular">
+            경매 등록
+          </Text>
+        </ModalHeader>
+        <ModalContent>
+          <ModalImageContainer>
+            <Image src={imageSrc} alt="모달 이미지" />
+            <Title>{title}</Title>
+          </ModalImageContainer>
+
+          <InputContainer>
+            <Text size={14} weight="medium">
+              시작 금액
+            </Text>
+            <Input
+              type="text"
+              placeholder="시작 금액 입력"
+              value={startPrice !== null ? formatPrice(startPrice) : ''}
+              onChange={handleInputChange}
+            />
+            <Text size={14} weight="medium">
+              원
+            </Text>
+          </InputContainer>
+        </ModalContent>
+        <ModalFooter>
+          <CommonButton
+            onClick={onClose}
+            text="취소"
+            color="black"
+            background="white"
+            borderColor={theme.colors.lightGray}
+            borderRadius="0px"
+          />
+          <CommonButton
+            onClick={handleConfirm}
+            text="확인"
+            color="white"
+            background="black"
+            borderColor="black"
+            borderRadius="0px"
+          />
+        </ModalFooter>
+      </ModalContainer>
+    </ModalOverlay>
+  );
+};
+
+export default AuctionModal;

--- a/src/pages/auction-register/hooks/useAuctionRegisterForm.ts
+++ b/src/pages/auction-register/hooks/useAuctionRegisterForm.ts
@@ -1,24 +1,70 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { TAuctionRegisterFormData } from '@/apis/auctionRegister/type';
+import { toast } from 'sonner';
 import { useState } from 'react';
-
-type TAuctionRegisterFormData = {
-  images: File[];
-  title: string;
-  startingPrice: number;
-  auctionEndDate: string;
-  description: string;
-};
-
-const useAuctionForm = () => {
+import { postAuctionRegisterMutation } from '@/constants/mutationKey';
+const useAuctionRegisterForm = () => {
   const [formData, setFormData] = useState<TAuctionRegisterFormData>({
-    images: [],
-    title: '',
-    startingPrice: 0,
-    auctionEndDate: '',
-    description: '',
+    artwork_id: null,
+    start_price: null,
+  });
+  const queryClient = useQueryClient();
+
+  /**
+   * 경매 등록 뮤테이션
+   * @author 홍규진
+   */
+  const mutation = useMutation({
+    mutationKey: postAuctionRegisterMutation().mutationKey,
+    mutationFn: (data: TAuctionRegisterFormData) =>
+      postAuctionRegisterMutation().mutationFn(data),
+    onSuccess: () => {
+      toast.success('경매 등록이 성공적으로 완료되었습니다.');
+      queryClient.invalidateQueries({
+        queryKey: postAuctionRegisterMutation().mutationKey,
+      });
+    },
+    onError: (error: Error) => {
+      toast.error(`경매 등록 실패: ${error.message}`);
+    },
   });
 
-  // 유효성 검사 및 제출 함수는 필요에 따라 추가
-  return { formData, setFormData };
+  /**
+   * 경매 등록 유효성 검사 함수
+   * @param data 경매 등록 폼 데이터
+   * @author 홍규진
+   */
+  const validateForm = (data: TAuctionRegisterFormData) => {
+    if (data.artwork_id === null) {
+      toast.error('작품을 선택해주세요.');
+      return false;
+    }
+    if (data.start_price === null) {
+      toast.error('시작 금액을 입력해주세요.');
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * 경매 등록 버튼 클릭 함수
+   * @param e 폼 제출 이벤트
+   * @author 홍규진
+   */
+  const handleSubmit = async () => {
+    if (validateForm(formData)) {
+      await mutation.mutateAsync(formData);
+    } else {
+      console.log('유효성 검사 실패');
+    }
+  };
+  return {
+    formData,
+    setFormData,
+    handleSubmit,
+    isLoading: mutation.isPending,
+    isError: mutation.isError,
+  };
 };
 
-export default useAuctionForm;
+export default useAuctionRegisterForm;

--- a/src/pages/auction-register/index.style.ts
+++ b/src/pages/auction-register/index.style.ts
@@ -4,15 +4,15 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 48px 24px;
+  padding: 24px 24px;
 `;
 
 export const ContentHeader = styled.div`
-  max-width: 1400px;
+  max-width: 1140px;
   margin: 0 auto;
-  padding: 48px 24px;
+  padding: 12px 24px;
   display: flex;
   flex-direction: column;
   align-items: start;

--- a/src/pages/auction-register/index.tsx
+++ b/src/pages/auction-register/index.tsx
@@ -51,8 +51,7 @@ export const AuctionRegister = () => {
             >
               <Artwork
                 imageUrl={artwork.thumbnail_image_url}
-                artist="작가 이름"
-                title="작품 제목"
+                title={artwork.title}
                 hoverable={false}
                 variant="eager"
               />

--- a/src/pages/auction-register/index.tsx
+++ b/src/pages/auction-register/index.tsx
@@ -8,40 +8,45 @@ import { Container, ButtonContainer, ContentHeader } from './index.style.ts';
 import Divider from '@/components/common/Divider/index.tsx';
 import theme from '@/styles/theme.ts';
 import { useGetAvailableArtwork } from './hooks/useGetAvailableArtwork';
+import { Text } from '@/styles/text.tsx';
+import AuctionModal from '@/pages/auction-register/components/AuctionModal';
+import useAuctionRegisterForm from './hooks/useAuctionRegisterForm';
 
 export const AuctionRegister = () => {
   const { availableArtworks } = useGetAvailableArtwork();
+  const [isModalOpen, setModalOpen] = useState(false);
   const [selectedImages, setSelectedImages] = useState<string[]>([]);
+  const { handleSubmit, formData, setFormData } = useAuctionRegisterForm();
 
-  const toggleImageSelection = (artworkId: string) => {
-    setSelectedImages((prev) =>
-      prev.includes(artworkId)
-        ? prev.filter((id) => id !== artworkId)
-        : [...prev, artworkId]
-    );
+  const handleOpenModal = (artworkId: number) => {
+    setFormData({ ...formData, artwork_id: artworkId });
+    setSelectedImages((prev) => [...prev, artworkId.toString()]);
+    setModalOpen(true);
   };
 
-  const handleRegister = () => {
-    // 등록 로직 추가
-    console.log('등록할 이미지:', selectedImages);
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
+  const handleModalConfirm = (price: number) => {
+    setFormData({ ...formData, start_price: price });
+    setModalOpen(false);
   };
 
   return (
     <PageLayout>
       <ContentHeader>
-        <h1>작품 등록</h1>
-        <p>
-          작품을 등록하기 위해서는 최소 1개 이상의 이미지를 업로드해야 합니다.
-        </p>
+        <Text size={24} weight="semibold">
+          경매 등록
+        </Text>
+        <Divider />
       </ContentHeader>
       <Container>
         <SquareGridContainer columnCount={5}>
           {availableArtworks?.map((artwork, index) => (
             <div
               key={artwork.artwork_id + index}
-              onClick={() =>
-                toggleImageSelection(artwork.artwork_id.toString())
-              }
+              onClick={() => handleOpenModal(artwork.artwork_id)}
               style={{
                 position: 'relative',
                 opacity: selectedImages.includes(artwork.artwork_id.toString())
@@ -85,10 +90,33 @@ export const AuctionRegister = () => {
             background={theme.colors.black}
             borderColor="black"
             borderRadius="2px"
-            onClick={handleRegister}
+            onClick={handleSubmit}
+            disabled={
+              formData.artwork_id === null || formData.start_price === null
+            }
           />
         </ButtonContainer>
       </Container>
+
+      <AuctionModal
+        isOpen={isModalOpen}
+        title={
+          formData.artwork_id
+            ? availableArtworks?.find(
+                (artwork) => artwork.artwork_id === formData.artwork_id
+              )?.title
+            : ''
+        }
+        imageSrc={
+          formData.artwork_id
+            ? availableArtworks?.find(
+                (artwork) => artwork.artwork_id === formData.artwork_id
+              )?.thumbnail_image_url
+            : ''
+        }
+        onClose={handleCloseModal}
+        onConfirm={(price) => handleModalConfirm(price)}
+      />
     </PageLayout>
   );
 };

--- a/src/pages/register/hooks/usePostAuthRegister.ts
+++ b/src/pages/register/hooks/usePostAuthRegister.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
-import { postAuthRegisterQuery } from '@/constants/queryKeys';
+import { postAuthRegisterMutation } from '@/constants/mutationKey';
 import { TRegisterFormData } from '@/apis/register/type';
 
 export const usePostAuthRegister = () => {
@@ -9,13 +9,14 @@ export const usePostAuthRegister = () => {
   const navigate = useNavigate();
 
   return useMutation({
-    mutationKey: postAuthRegisterQuery().queryKey,
-    mutationFn: (body: TRegisterFormData) =>
-      postAuthRegisterQuery().queryFn(body),
+    mutationKey: postAuthRegisterMutation().mutationKey,
+    mutationFn: (formData: TRegisterFormData) =>
+      postAuthRegisterMutation().mutationFn(formData),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: postAuthRegisterQuery().queryKey,
+        queryKey: postAuthRegisterMutation().mutationKey,
       }); // 쿼리 무효화
+      toast.success('회원가입이 완료되었습니다.');
       navigate('/success'); // 성공 페이지로 이동
     },
     onError: (error: Error) => {


### PR DESCRIPTION
## 작업 사항

- 공통 컴포넌트 수정 optional 추가 및 확장성 고려 (Artwork- artist optional 추가 , ThemeChooser - 부모객체로부터 onChange)
- 경매 등록페이지 artist 제거
- 작품 등록 API 구현 및 Multipart-FormData 예시 구현 
- 다음과 같이 formData.append 하는 형식으로 이미지를 첨부해서 요청해야만 Backend에서 처리할 수 있습니다!!
```tsx
import { instance } from '@/apis/axios';
import { TGetResponse } from '@/apis/type';
import { TArtworkRegisterFormData } from './type';

/**
 * 작품 등록 API 함수
 * @param data 작품 등록 폼 데이터 (파일 전송을 위해 FormData 형태로 변환됩니다.)
 * @returns 등록 결과를 포함한 응답(TGetResponse<void>)
 */
export const postArtworkRegister = async (
  data: TArtworkRegisterFormData
): Promise<TGetResponse<void>> => {
  // 이미지 파일과 텍스트 필드를 함께 전송하기 위해 FormData 사용
  const formData = new FormData();

  // images 필드는 File 배열이므로 반복문을 사용하여 첨부
  data.images.forEach((file) => {
    formData.append('images', file);
  });

  // 나머지 텍스트 데이터 추가
  formData.append('theme', data.theme);
  formData.append('form', data.form);
  formData.append('title', data.title);
  formData.append('year', data.year);
  formData.append('genre', data.genre);
  formData.append('material', data.material);
  formData.append('description', data.description);
  formData.append('height', data.height);
  formData.append('width', data.width);
  formData.append('number', data.number);
  formData.append('frame', data.frame);

  const response = await instance.post<TGetResponse<void>>(
    '/api/artworks',
    formData,
    {
      headers: {
        'Content-Type': 'multipart/form-data',
      },
    }
  );
  console.log(response.data);
  return response.data;
};
```
https://github.com/user-attachments/assets/40031425-c9b1-46de-88eb-16e97e0079b1


## 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
